### PR TITLE
feat: Add node-cron dependency

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,6 +17,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.1",
         "mysql2": "^3.6.5",
+        "node-cron": "^4.1.0",
         "nodemailer": "^7.0.3",
         "puppeteer": "^24.9.0"
       },
@@ -5348,6 +5349,15 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+    },
+    "node_modules/node-cron": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.1.0.tgz",
+      "integrity": "sha512-OS+3ORu+h03/haS6Di8Qr7CrVs4YaKZZOynZwQpyPZDnR3tqRbwJmuP2gVR16JfhLgyNlloAV1VTrrWlRogCFA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.1",
     "mysql2": "^3.6.5",
+    "node-cron": "^4.1.0",
     "nodemailer": "^7.0.3",
     "puppeteer": "^24.9.0"
   },


### PR DESCRIPTION
Adds the node-cron library to the project's dependencies. This
library will be used to schedule recurring tasks, such as
sending automated emails or performing data maintenance
operations.