### PR TITLE
fix(email-service):  remove non-existent description column from scheduler query

### DIFF
--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -1200,7 +1200,7 @@ async function processScheduledNotifications() {
     // Get all enabled notifications that are due to be sent
     // For monthly reports, this should run on the 1st of each month
     const [notifications] = await pool.query(
-      `SELECT rn.*, sr.name, sr.description, sr.category, sr.config, u.full_name as user_name
+      `SELECT rn.*, sr.name, sr.category, sr.config, u.full_name as user_name
        FROM report_notifications rn
        JOIN saved_reports sr ON rn.report_id = sr.id
        JOIN users u ON rn.user_id = u.id
@@ -1254,7 +1254,6 @@ async function processScheduledNotifications() {
         const report = {
           id: notification.report_id,
           name: notification.name,
-          description: notification.description,
           category: notification.category,
         };
 


### PR DESCRIPTION
fix: remove non-existent description column from scheduler query

The email scheduler was failing with "Unknown column 'sr.description'" error
because the saved_reports table doesn't have a description column. This was
preventing scheduled notifications from being processed.

Changes:
- Remove sr.description from SELECT query in processScheduledNotifications()
- Remove description field from report object construction
- Scheduler can now successfully query and process notifications

Fixes email scheduler functionality while maintaining compatibility with
existing database schema.