### PR TITLE
fix(pdf): add serverless chromium support for PDF generation

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ddrc-server",
       "version": "1.0.0",
       "dependencies": {
+        "@sparticuz/chromium": "^133.0.0",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
@@ -22,6 +23,7 @@
         "node-cron": "^4.1.0",
         "nodemailer": "^7.0.3",
         "puppeteer": "^24.34.0",
+        "puppeteer-core": "^24.34.0",
         "xss": "^1.0.15"
       },
       "devDependencies": {
@@ -1141,6 +1143,19 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sparticuz/chromium": {
+      "version": "133.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-133.0.0.tgz",
+      "integrity": "sha512-wioNxMtSxRI+Y6ymc/UFPX9lY7A1SDgBezjFITH6arwe5CONfWosNDGpgflUGYajxxGktb1k3kjJ83jWzbccBw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.9",
+        "tar-fs": "^3.0.8"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -3283,6 +3298,26 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@sparticuz/chromium": "^133.0.0",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
@@ -26,6 +27,7 @@
     "node-cron": "^4.1.0",
     "nodemailer": "^7.0.3",
     "puppeteer": "^24.34.0",
+    "puppeteer-core": "^24.34.0",
     "xss": "^1.0.15"
   },
   "devDependencies": {


### PR DESCRIPTION
fix: enable PDF generation on Azure with serverless Chromium

- Replace puppeteer with environment-aware browser selection
- Use @sparticuz/chromium for Azure/serverless production
- Use regular puppeteer for local development
- Add applicant photo and name to PDF applicant card
- Fix photo path resolution (server/uploads/forms/)
- Remove debug console.log statements from dashboard.js
- Clean up unused PDFKit code and fonts


Resolves "Could not find Chrome" error on Azure App Service