### PR TITLE
feat(pdf): simplify Puppeteer browser launch configuration

### DIFF
--- a/server/.puppeteerrc.cjs
+++ b/server/.puppeteerrc.cjs
@@ -1,0 +1,9 @@
+const { join } = require('path');
+
+/**
+ * @type {import("puppeteer").Configuration}
+ */
+module.exports = {
+    // Change the cache directory for Puppeteer to /home (persists on Azure App Service)
+    cacheDirectory: join(__dirname, '.cache', 'puppeteer'),
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,7 +8,6 @@
       "name": "ddrc-server",
       "version": "1.0.0",
       "dependencies": {
-        "@sparticuz/chromium": "^133.0.0",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
@@ -23,7 +22,6 @@
         "node-cron": "^4.1.0",
         "nodemailer": "^7.0.3",
         "puppeteer": "^24.34.0",
-        "puppeteer-core": "^24.34.0",
         "xss": "^1.0.15"
       },
       "devDependencies": {
@@ -1143,19 +1141,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/@sparticuz/chromium": {
-      "version": "133.0.0",
-      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-133.0.0.tgz",
-      "integrity": "sha512-wioNxMtSxRI+Y6ymc/UFPX9lY7A1SDgBezjFITH6arwe5CONfWosNDGpgflUGYajxxGktb1k3kjJ83jWzbccBw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.9",
-        "tar-fs": "^3.0.8"
-      },
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -3298,26 +3283,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
       }
     },
     "node_modules/form-data": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,6 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@sparticuz/chromium": "^133.0.0",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
@@ -27,7 +26,6 @@
     "node-cron": "^4.1.0",
     "nodemailer": "^7.0.3",
     "puppeteer": "^24.34.0",
-    "puppeteer-core": "^24.34.0",
     "xss": "^1.0.15"
   },
   "devDependencies": {

--- a/server/utils/pdfGenerator.js
+++ b/server/utils/pdfGenerator.js
@@ -358,28 +358,14 @@ async function generateApplicationPDF(applicationData, profileData) {
 </html>
     `;
 
-    // Launch browser - use serverless chromium in production, regular puppeteer locally
-    let browser;
-    const isProduction = process.env.NODE_ENV === 'production' || process.env.WEBSITE_SITE_NAME;
-
-    if (isProduction) {
-        // Azure/serverless: use puppeteer-core with @sparticuz/chromium
-        const puppeteerCore = require('puppeteer-core');
-        const chromium = require('@sparticuz/chromium');
-        browser = await puppeteerCore.launch({
-            args: chromium.args,
-            defaultViewport: chromium.defaultViewport,
-            executablePath: await chromium.executablePath(),
-            headless: chromium.headless
-        });
-    } else {
-        // Local development: use regular puppeteer with bundled Chromium
-        const puppeteerLocal = require('puppeteer');
-        browser = await puppeteerLocal.launch({
-            headless: 'new',
-            args: ['--no-sandbox', '--disable-setuid-sandbox']
-        });
-    }
+    // Launch Puppeteer
+    // On Azure: chromium is installed via startup script (apt-get install chromium)
+    // Locally: puppeteer bundles its own Chromium
+    const puppeteer = require('puppeteer');
+    const browser = await puppeteer.launch({
+        headless: 'new',
+        args: ['--no-sandbox', '--disable-setuid-sandbox']
+    });
 
     try {
         const page = await browser.newPage();


### PR DESCRIPTION
Remove serverless Chromium dependencies and streamline browser
launch process across environments. Update configuration to use
standard Puppeteer launch method with consistent settings.