### PR TITLE
feat(uploads): Add Azure Blob Storage for persistent file uploads

### DIFF
--- a/server/middleware/uploadMiddleware.js
+++ b/server/middleware/uploadMiddleware.js
@@ -2,35 +2,11 @@ const multer = require("multer");
 const path = require("path");
 const fs = require("fs");
 const { uploadsDir, generateUniqueFilename } = require("../config/upload");
+const storageService = require("../services/storageService");
 
-// Configure multer for file uploads
-const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
-    // Determine destination based on file type or route
-    let uploadPath = path.join(uploadsDir);
-
-    // Default to forms directory if no specific directory is determined
-    if (req.originalUrl.includes("/news")) {
-      uploadPath = path.join(uploadsDir, "news");
-    } else if (req.originalUrl.includes("/events")) {
-      uploadPath = path.join(uploadsDir, "events");
-    } else {
-      uploadPath = path.join(uploadsDir, "forms");
-    }
-
-    // Ensure the directory exists
-    if (!fs.existsSync(uploadPath)) {
-      fs.mkdirSync(uploadPath, { recursive: true });
-    }
-
-    cb(null, uploadPath);
-  },
-  filename: (req, file, cb) => {
-    // Generate a unique filename to prevent overwriting
-    const uniqueFilename = generateUniqueFilename(file.originalname);
-    cb(null, uniqueFilename);
-  },
-});
+// Use memory storage - files are saved by storageService after processing
+// This allows us to switch between local and Azure Blob storage seamlessly
+const storage = multer.memoryStorage();
 
 // Filter function to validate file types if needed
 const fileFilter = (req, file, cb) => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ddrc-server",
       "version": "1.0.0",
       "dependencies": {
+        "@azure/storage-blob": "^12.26.0",
         "@google/generative-ai": "^0.24.1",
         "@signpdf/placeholder-pdf-lib": "^3.2.6",
         "@signpdf/signer-p12": "^3.2.4",
@@ -52,6 +53,185 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.9.0.tgz",
+      "integrity": "sha512-FPwHpZywuyasDSLMqJ6fhbOK3TqUdviZNF8OqRGA4W5Ewib2lEEZ+pBsYcBa88B2NGO/SEnYPGhyBqNlE8ilSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.4.tgz",
+      "integrity": "sha512-f7IxTD15Qdux30s2qFARH+JxgwxWLG2Rlr4oSkPGuLWm+1p5y1+C04XGLA0vmX6EtqfutmjvpNmAfgwVIS5hpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-rest-pipeline": "^1.20.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http-compat": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.3.0.tgz",
+      "integrity": "sha512-qLQujmUypBBG0gxHd0j6/Jdmul6ttl24c8WGiLXIk7IHXdBlfoBqW27hyz3Xn6xbfdyVSarl1Ttbk0AwnZBYCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-client": "^1.3.0",
+        "@azure/core-rest-pipeline": "^1.20.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-lro": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+      "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-util": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.21.0.tgz",
+      "integrity": "sha512-a4MBwe/5WKbq9MIxikzgxLBbruC5qlkFYlBdI7Ev50Y7ib5Vo/Jvt5jnJo7NaWeJ908LCHL0S1Us4UMf1VoTfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.8.0",
+        "@azure/core-tracing": "^1.0.1",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@typespec/ts-http-runtime": "^0.2.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.2.0.tgz",
+      "integrity": "sha512-UKTiEJPkWcESPYJz3X5uKRYyOcJD+4nYph+KpfdPRnQJVrZfk0KJgdnaAWKfhsBBtAf/D58Az4AvCJEmWgIBAg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.12.0.tgz",
+      "integrity": "sha512-13IyjTQgABPARvG90+N2dXpC+hwp466XCdQXPCRlbWHgd3SJd5Q1VvaBGv6k1BIa4MQm6hAF1UBU1m8QUxV8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@typespec/ts-http-runtime": "^0.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.4.5.tgz",
+      "integrity": "sha512-gT4H8mTaSXRz7eGTuQyq1aIJnJqeXzpOe9Ay7Z3FrCouer14CbV3VzjnJrNrQfbBpGBLO9oy8BmrY75A0p53cA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.0.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.2.0.tgz",
+      "integrity": "sha512-0hKEzLhpw+ZTAfNJyRrn6s+V0nDWzXk9OjBr2TiGIu0OfMr5s2V4FpKLTAK3Ca5r5OKLbf4hkOGDPyiRjie/jA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/storage-blob": {
+      "version": "12.27.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.27.0.tgz",
+      "integrity": "sha512-IQjj9RIzAKatmNca3D6bT0qJ+Pkox1WZGOg2esJF2YLHb45pQKOwGPIAV+w3rfgkj7zV3RMxpn/c6iftzSOZJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.4.0",
+        "@azure/core-client": "^1.6.2",
+        "@azure/core-http-compat": "^2.0.0",
+        "@azure/core-lro": "^2.2.0",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-rest-pipeline": "^1.10.1",
+        "@azure/core-tracing": "^1.1.2",
+        "@azure/core-util": "^1.6.1",
+        "@azure/core-xml": "^1.4.3",
+        "@azure/logger": "^1.0.0",
+        "events": "^3.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1418,6 +1598,65 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.2.3.tgz",
+      "integrity": "sha512-oRhjSzcVjX8ExyaF8hC0zzTqxlVuRlgMHL/Bh4w3xB9+wjbm0FpXylVU/lBrn+kgphwYTrOk3tp+AVShGmlYCg==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -3236,6 +3475,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -3477,6 +3725,24 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.3.tgz",
+      "integrity": "sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -7239,6 +7505,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "9.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
+    "@azure/storage-blob": "^12.26.0",
     "@google/generative-ai": "^0.24.1",
     "@signpdf/placeholder-pdf-lib": "^3.2.6",
     "@signpdf/signer-p12": "^3.2.4",

--- a/server/services/storageService.js
+++ b/server/services/storageService.js
@@ -1,0 +1,356 @@
+/**
+ * Storage Service - Environment-aware file storage abstraction
+ * Uses local disk in development, Azure Blob Storage in production
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { BlobServiceClient, generateBlobSASQueryParameters, BlobSASPermissions, StorageSharedKeyCredential } = require('@azure/storage-blob');
+
+class StorageService {
+    constructor() {
+        this.useAzure = process.env.NODE_ENV === 'production' &&
+            !!process.env.AZURE_STORAGE_CONNECTION_STRING;
+
+        this.localUploadsDir = path.join(__dirname, '../uploads');
+        this.containerName = process.env.AZURE_STORAGE_CONTAINER || 'uploads';
+
+        // Initialize Azure Blob client in production
+        if (this.useAzure) {
+            try {
+                this.blobServiceClient = BlobServiceClient.fromConnectionString(
+                    process.env.AZURE_STORAGE_CONNECTION_STRING
+                );
+                this.containerClient = this.blobServiceClient.getContainerClient(this.containerName);
+
+                // Parse connection string for SAS generation
+                this._parseConnectionString();
+
+                console.log('✅ Azure Blob Storage initialized');
+            } catch (error) {
+                console.error('❌ Failed to initialize Azure Blob Storage:', error.message);
+                // Fall back to local storage
+                this.useAzure = false;
+            }
+        } else {
+            console.log('📁 Using local file storage');
+        }
+
+        // Ensure local uploads directory exists
+        this._ensureLocalDirs();
+    }
+
+    /**
+     * Parse connection string to extract account details for SAS generation
+     */
+    _parseConnectionString() {
+        const connStr = process.env.AZURE_STORAGE_CONNECTION_STRING || '';
+        const parts = {};
+        connStr.split(';').forEach(part => {
+            const [key, ...valueParts] = part.split('=');
+            if (key && valueParts.length) {
+                parts[key] = valueParts.join('=');
+            }
+        });
+
+        this.accountName = parts['AccountName'];
+        this.accountKey = parts['AccountKey'];
+
+        if (this.accountName && this.accountKey) {
+            this.sharedKeyCredential = new StorageSharedKeyCredential(
+                this.accountName,
+                this.accountKey
+            );
+        }
+    }
+
+    /**
+     * Ensure local upload directories exist
+     */
+    _ensureLocalDirs() {
+        const dirs = ['', 'news', 'events', 'forms', 'documents', 'admin'];
+        dirs.forEach(dir => {
+            const fullPath = path.join(this.localUploadsDir, dir);
+            if (!fs.existsSync(fullPath)) {
+                fs.mkdirSync(fullPath, { recursive: true });
+            }
+        });
+    }
+
+    /**
+     * Generate a unique filename
+     */
+    generateFilename(originalname) {
+        const timestamp = Date.now();
+        const hash = crypto.randomBytes(8).toString('hex');
+        const cleanName = originalname.replace(/[^a-zA-Z0-9.]/g, '_');
+        const ext = path.extname(cleanName);
+        const baseName = path.basename(cleanName, ext);
+        return `${timestamp}-${hash}-${baseName}${ext}`;
+    }
+
+    /**
+     * Save a file to storage
+     * @param {Buffer} buffer - File buffer
+     * @param {string} folder - Folder name (news, events, forms, documents)
+     * @param {string} filename - Filename to save as
+     * @returns {Promise<string>} - Relative file path (e.g., "news/1234-abc.pdf")
+     */
+    async saveFile(buffer, folder, filename) {
+        const relativePath = `${folder}/${filename}`;
+
+        if (this.useAzure) {
+            return await this._saveToAzure(buffer, relativePath);
+        } else {
+            return await this._saveToLocal(buffer, relativePath);
+        }
+    }
+
+    /**
+     * Save file to local disk
+     */
+    async _saveToLocal(buffer, relativePath) {
+        const fullPath = path.join(this.localUploadsDir, relativePath);
+        const dir = path.dirname(fullPath);
+
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+        }
+
+        await fs.promises.writeFile(fullPath, buffer);
+        return relativePath;
+    }
+
+    /**
+     * Save file to Azure Blob Storage
+     */
+    async _saveToAzure(buffer, relativePath) {
+        const blockBlobClient = this.containerClient.getBlockBlobClient(relativePath);
+
+        // Determine content type based on extension
+        const ext = path.extname(relativePath).toLowerCase();
+        const contentType = this._getContentType(ext);
+
+        await blockBlobClient.upload(buffer, buffer.length, {
+            blobHTTPHeaders: { blobContentType: contentType }
+        });
+
+        return relativePath;
+    }
+
+    /**
+     * Delete a file from storage
+     * @param {string} relativePath - Relative path (e.g., "news/1234-abc.pdf")
+     */
+    async deleteFile(relativePath) {
+        if (!relativePath) return;
+
+        // Clean the path - remove leading /uploads/ if present
+        const cleanPath = relativePath.replace(/^\/?(uploads\/)?/, '');
+
+        if (this.useAzure) {
+            return await this._deleteFromAzure(cleanPath);
+        } else {
+            return await this._deleteFromLocal(cleanPath);
+        }
+    }
+
+    /**
+     * Delete file from local disk
+     */
+    async _deleteFromLocal(relativePath) {
+        const fullPath = path.join(this.localUploadsDir, relativePath);
+
+        try {
+            if (fs.existsSync(fullPath)) {
+                await fs.promises.unlink(fullPath);
+            }
+        } catch (error) {
+            console.error(`Error deleting local file ${relativePath}:`, error.message);
+        }
+    }
+
+    /**
+     * Delete file from Azure Blob Storage
+     */
+    async _deleteFromAzure(relativePath) {
+        try {
+            const blockBlobClient = this.containerClient.getBlockBlobClient(relativePath);
+            await blockBlobClient.deleteIfExists();
+        } catch (error) {
+            console.error(`Error deleting blob ${relativePath}:`, error.message);
+        }
+    }
+
+    /**
+     * Get a URL for accessing a file
+     * For public files (news, events): direct URL or local path
+     * For private files (forms, documents): SAS URL with expiry
+     * 
+     * @param {string} relativePath - Relative path (e.g., "forms/1234-abc.pdf")
+     * @param {object} options - Options
+     * @param {boolean} options.private - Generate SAS token for private access
+     * @param {number} options.expiryMinutes - SAS token expiry in minutes (default: 60)
+     * @returns {string} - URL to access the file
+     */
+    getFileUrl(relativePath, options = {}) {
+        if (!relativePath) return null;
+
+        // Clean the path
+        const cleanPath = relativePath.replace(/^\/?(uploads\/)?/, '');
+
+        if (this.useAzure) {
+            return this._getAzureUrl(cleanPath, options);
+        } else {
+            // For local, return the relative path that Express will serve
+            return `/uploads/${cleanPath}`;
+        }
+    }
+
+    /**
+     * Get Azure Blob URL with optional SAS token
+     */
+    _getAzureUrl(relativePath, options = {}) {
+        const blockBlobClient = this.containerClient.getBlockBlobClient(relativePath);
+
+        if (options.private && this.sharedKeyCredential) {
+            // Generate SAS token for private access
+            const expiryMinutes = options.expiryMinutes || 60;
+            const expiresOn = new Date(Date.now() + expiryMinutes * 60 * 1000);
+
+            const sasToken = generateBlobSASQueryParameters({
+                containerName: this.containerName,
+                blobName: relativePath,
+                permissions: BlobSASPermissions.parse('r'), // Read only
+                expiresOn: expiresOn,
+            }, this.sharedKeyCredential).toString();
+
+            return `${blockBlobClient.url}?${sasToken}`;
+        }
+
+        // Public URL
+        return blockBlobClient.url;
+    }
+
+    /**
+     * Get a readable stream for a file
+     * @param {string} relativePath - Relative path
+     * @returns {Promise<ReadableStream>}
+     */
+    async getFileStream(relativePath) {
+        if (!relativePath) return null;
+
+        // Clean the path
+        const cleanPath = relativePath.replace(/^\/?(uploads\/)?/, '');
+
+        if (this.useAzure) {
+            return await this._getAzureStream(cleanPath);
+        } else {
+            return this._getLocalStream(cleanPath);
+        }
+    }
+
+    /**
+     * Get local file stream
+     */
+    _getLocalStream(relativePath) {
+        const fullPath = path.join(this.localUploadsDir, relativePath);
+
+        if (!fs.existsSync(fullPath)) {
+            throw new Error('File not found');
+        }
+
+        return fs.createReadStream(fullPath);
+    }
+
+    /**
+     * Get Azure Blob stream
+     */
+    async _getAzureStream(relativePath) {
+        const blockBlobClient = this.containerClient.getBlockBlobClient(relativePath);
+        const downloadResponse = await blockBlobClient.download(0);
+        return downloadResponse.readableStreamBody;
+    }
+
+    /**
+     * Check if a file exists
+     * @param {string} relativePath - Relative path
+     * @returns {Promise<boolean>}
+     */
+    async fileExists(relativePath) {
+        if (!relativePath) return false;
+
+        const cleanPath = relativePath.replace(/^\/?(uploads\/)?/, '');
+
+        if (this.useAzure) {
+            try {
+                const blockBlobClient = this.containerClient.getBlockBlobClient(cleanPath);
+                return await blockBlobClient.exists();
+            } catch {
+                return false;
+            }
+        } else {
+            const fullPath = path.join(this.localUploadsDir, cleanPath);
+            return fs.existsSync(fullPath);
+        }
+    }
+
+    /**
+     * Get content type from file extension
+     */
+    _getContentType(ext) {
+        const types = {
+            '.pdf': 'application/pdf',
+            '.doc': 'application/msword',
+            '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            '.xls': 'application/vnd.ms-excel',
+            '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            '.jpg': 'image/jpeg',
+            '.jpeg': 'image/jpeg',
+            '.png': 'image/png',
+            '.gif': 'image/gif',
+            '.webp': 'image/webp',
+        };
+        return types[ext] || 'application/octet-stream';
+    }
+
+    /**
+     * Get file info (size, content type)
+     * @param {string} relativePath - Relative path
+     * @returns {Promise<{size: number, contentType: string} | null>}
+     */
+    async getFileInfo(relativePath) {
+        if (!relativePath) return null;
+
+        const cleanPath = relativePath.replace(/^\/?(uploads\/)?/, '');
+
+        if (this.useAzure) {
+            try {
+                const blockBlobClient = this.containerClient.getBlockBlobClient(cleanPath);
+                const properties = await blockBlobClient.getProperties();
+                return {
+                    size: properties.contentLength,
+                    contentType: properties.contentType,
+                };
+            } catch {
+                return null;
+            }
+        } else {
+            const fullPath = path.join(this.localUploadsDir, cleanPath);
+            try {
+                const stats = await fs.promises.stat(fullPath);
+                const ext = path.extname(cleanPath).toLowerCase();
+                return {
+                    size: stats.size,
+                    contentType: this._getContentType(ext),
+                };
+            } catch {
+                return null;
+            }
+        }
+    }
+}
+
+// Export singleton instance
+module.exports = new StorageService();


### PR DESCRIPTION
Add environment-aware storage service for file uploads

- Create storageService.js - auto-switches between local disk (dev) and Azure Blob (prod)
- Update all upload routes (news, events, registration) to use memory storage + storageService
- Update file serving middleware in server.js to stream from storage service
- Add @azure/storage-blob dependency

When AZURE_STORAGE_CONNECTION_STRING is set in production, files are stored in 
Azure Blob Storage for persistence across App Service restarts/deployments.
Local development continues to use /server/uploads/ with no config changes needed.