### PR TITLE
fix(uploads): Skip local uploads directory creation in production

### DIFF
--- a/server/config/upload.js
+++ b/server/config/upload.js
@@ -6,8 +6,9 @@ const crypto = require("crypto");
 const uploadsDir =
   process.env.UPLOADS_DIR || path.join(__dirname, "../uploads");
 
-// Create uploads directory if it doesn't exist
-if (!fs.existsSync(uploadsDir)) {
+// Create uploads directory if it doesn't exist (skip in production - uses Azure Blob Storage)
+const isProduction = process.env.NODE_ENV === 'production';
+if (!isProduction && !fs.existsSync(uploadsDir)) {
   fs.mkdirSync(uploadsDir, { recursive: true });
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -44,18 +44,21 @@ if (process.env.NODE_ENV === 'production' || process.env.TRUST_PROXY === 'true')
   console.log('✅ Trust proxy enabled for load balancer/Azure');
 }
 
-// Create uploads directories if they don't exist
-const uploadDirs = [
-  path.join(__dirname, "uploads"),
-  path.join(__dirname, "uploads/news"),
-  path.join(__dirname, "uploads/forms"),
-  path.join(__dirname, "uploads/documents"),];
+// Create uploads directories if they don't exist (skip in production - uses Azure Blob Storage)
+if (process.env.NODE_ENV !== 'production') {
+  const uploadDirs = [
+    path.join(__dirname, "uploads"),
+    path.join(__dirname, "uploads/news"),
+    path.join(__dirname, "uploads/forms"),
+    path.join(__dirname, "uploads/documents"),
+  ];
 
-uploadDirs.forEach((dir) => {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-});
+  uploadDirs.forEach((dir) => {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  });
+}
 
 // Helper function for consistent API error responses
 const apiErrorResponse = (res, status, message) => {


### PR DESCRIPTION
Modify upload directory creation logic to skip creating local
directories when running in production environment. This change
ensures compatibility with Azure Blob Storage and prevents
unnecessary filesystem operations during deployment.