### PR TITLE
feat(forms): Add drag-and-drop reordering for sections and fields

### DIFF
--- a/public/admin/css/style.css
+++ b/public/admin/css/style.css
@@ -261,6 +261,7 @@
   display: flex;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .field-name {
@@ -288,6 +289,60 @@
 .field-actions {
   display: flex;
   gap: 0.5rem;
+}
+
+/* Drag Handle Styles */
+.drag-handle {
+  cursor: grab;
+  opacity: 0.4;
+  transition: opacity 0.2s;
+  display: none;
+  /* Hidden by default */
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  margin-right: 0.5rem;
+  color: #6b7280;
+}
+
+/* Show drag handles only in reorder mode */
+.reorder-mode .drag-handle {
+  display: inline-flex;
+}
+
+.drag-handle:hover {
+  opacity: 1;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
+.section-header .drag-handle {
+  margin-right: 1rem;
+}
+
+/* Reorder mode indicator */
+.reorder-mode .sections-container {
+  background: #fef3c7;
+  border-radius: 8px;
+  padding: 0.5rem;
+}
+
+/* SortableJS States */
+.sortable-ghost {
+  opacity: 0.4;
+  background: #f3f4f6;
+}
+
+.sortable-drag {
+  opacity: 1;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+  transform: rotate(2deg);
+}
+
+.sortable-chosen {
+  cursor: grabbing;
 }
 
 .modal-dialog-centered {
@@ -3423,6 +3478,22 @@ html body .clickable-row:active td {
     flex: 1;
   }
 
+  /* Drag handles - larger for touch */
+  .drag-handle {
+    padding: 0.5rem;
+    opacity: 0.6;
+  }
+
+  .drag-handle svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  .section-header .drag-handle svg {
+    width: 24px;
+    height: 24px;
+  }
+
   /* Field modal */
   .modal-dialog {
     margin: 0.5rem;
@@ -3450,6 +3521,11 @@ html body .clickable-row:active td {
     flex-direction: column;
     align-items: flex-start !important;
     gap: 1rem;
+  }
+
+  .card-header .d-flex {
+    flex-direction: column;
+    width: 100%;
   }
 
   .card-header .btn {

--- a/public/admin/forms/index.html
+++ b/public/admin/forms/index.html
@@ -71,9 +71,14 @@
       <div class="content-card">
         <div class="card-header d-flex justify-content-between align-items-center">
           <h2>Form Sections</h2>
-          <button class="btn btn-primary" id="addSectionBtn">
-            Add Section
-          </button>
+          <div class="d-flex gap-2">
+            <button class="btn btn-outline-secondary" id="toggleReorderBtn">
+              Reorder
+            </button>
+            <button class="btn btn-primary" id="addSectionBtn">
+              Add Section
+            </button>
+          </div>
         </div>
 
         <div class="sections-container">
@@ -299,6 +304,7 @@
   </div>
 
   <!-- Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="/js/auth.js"></script>
   <script src="/admin/js/api.js"></script>

--- a/server/server.js
+++ b/server/server.js
@@ -183,7 +183,7 @@ app.use(
       }
     },
     credentials: true,
-    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allowedHeaders: ["Content-Type", "Authorization"],
   })
 );


### PR DESCRIPTION
Implemented a comprehensive reordering system for the Form Management page
with toggle control and full mobile responsiveness.

Backend Changes:
- Added PATCH /api/form/sections/reorder endpoint with admin auth
- Added PATCH /api/form/fields/reorder endpoint with admin auth
- Both endpoints use database transactions for atomicity
- Added PATCH method to CORS configuration

Frontend Changes:
- Integrated SortableJS for drag-and-drop functionality
- Added "Reorder" toggle button to enable/disable dragging
- Drag handles hidden by default, shown only in reorder mode
- Visual feedback with green button and yellow background tint
- Fully responsive on mobile with touch-friendly controls

Security:
- All endpoints protected with authentication and admin role check
- Input validation for array parameters
- Transaction-based updates prevent partial data corruption

UX Improvements:
- Clean interface when not reordering
- Clear visual indicators when reorder mode is active
- Prevents accidental reordering
- Smooth animations and transitions

Files modified: 5 (332 additions, 5 deletions)