### PR TITLE
fix: remove duplicate os import causing crash in emailService

### DIFF
--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -398,8 +398,6 @@ function getCurrentMonthYear() {
   return date.toLocaleString("default", { month: "long", year: "numeric" });
 }
 
-const os = require('os');
-
 /**
  * Generate a report file
  * @param {string} reportName - The name of the report


### PR DESCRIPTION
Fix email service by removing unnecessary os module import
that was not being used in the current implementation.