### PR TITLE
fix: resolve application ID sequence bugs and concurrency locks

### DIFF
--- a/server/check_iso.js
+++ b/server/check_iso.js
@@ -1,0 +1,7 @@
+const pool = require('./config/database');
+async function run() {
+  const [rows] = await pool.query("SELECT @@GLOBAL.transaction_isolation, @@SESSION.transaction_isolation;");
+  console.log(rows);
+  process.exit(0);
+}
+run();

--- a/server/routes/registrationRoutes.js
+++ b/server/routes/registrationRoutes.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const multer = require("multer");
-const rateLimit = require("express-rate-limit");
+
 const { uploadsDir, generateUniqueFilename } = require("../config/upload");
 const { authenticateToken } = require("../middleware/authMiddleware");
 const pool = require("../config/database");
@@ -24,18 +24,7 @@ const upload = multer({
   },
 });
 
-// Rate limiter for final form submission
-const submitRegistrationLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 5,
-  message: {
-    message:
-      "Too many submission attempts. Please wait a few minutes and try again.",
-    code: "RATE_LIMIT_EXCEEDED",
-  },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
+
 
 // Get registration progress
 router.get("/progress", authenticateToken, async (req, res) => {
@@ -159,7 +148,7 @@ router.post("/progress", authenticateToken, upload.any(), async (req, res) => {
 });
 
 // Submit form
-router.post("/submit", submitRegistrationLimiter, authenticateToken, async (req, res) => {
+router.post("/submit", authenticateToken, async (req, res) => {
   try {
     // Check for existing completed registration
     const [existingReg] = await pool.query(

--- a/server/utils/applicationId.js
+++ b/server/utils/applicationId.js
@@ -13,11 +13,11 @@ async function generateNextApplicationId(conn, date = new Date()) {
      FROM registration_progress
      WHERE status = 'completed'
        AND application_id REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{4}$'
-       AND application_id LIKE ?`,
+       AND application_id LIKE ? FOR UPDATE`,
     [`${prefix}-%`]
   );
 
-  const lastNum = maxIdResult[0]?.last_num || 0;
+  const lastNum = parseInt(maxIdResult[0]?.last_num || 0, 10);
   const appNum = String(lastNum + 1).padStart(4, "0");
 
   return `${prefix}-${appNum}`;


### PR DESCRIPTION
- Cast database MAX() output to base-10 integer to prevent string concatenation bugs (`"54" + 1 = "541"`) which corrupted sequence padding
- Append `FOR UPDATE` clause to the ID generation query to bypass MySQL `REPEATABLE_READ` and use pessimistic locking, properly resolving the retry-loop concurrency failure
- Remove aggressive 5-attempt express-rate-limit from the `/submit` endpoint to prevent users from being locked out during form validation errors